### PR TITLE
Pass block to starting_blocks' Bash.run

### DIFF
--- a/lib/rspec_contract.rb
+++ b/lib/rspec_contract.rb
@@ -11,7 +11,8 @@
   def execute_these_files files
     requires = files.map { |x| "require '#{x}'" }.join("\n")
     command = "rspec #{files.join(" ")}"
-    StartingBlocks::Bash.run command
+    block = Proc.new { |command| system( command ) }
+    StartingBlocks::Bash.run command, block
   end
 
 end


### PR DESCRIPTION
This will allow the output of running RSpec to have color. However, this
comes at the expense of not being able to integrate this RSpec plugin
with the Growl plugin.

This is dependent on starting_blocks implementing the optional block change in bash.rb
